### PR TITLE
Autocomplete fix for chrome warning resolution

### DIFF
--- a/mapp_v4/login/login_en.html
+++ b/mapp_v4/login/login_en.html
@@ -21,7 +21,7 @@
 
 <body>
   <main>
-<!--     <div class="lang-container">
+    <!--     <div class="lang-container">
       <label for="language">
         <select id="language" onChange="window.location.href=this.value">
           <option value="{{dir}}?language=en&login=true">English</option>
@@ -47,13 +47,14 @@
 
             <div class="form-field">
               <label>Email address</label>
-              <input name="email" type="email" required maxlength="50" placeholder="Enter email">
+              <input name="email" type="email" required maxlength="50" placeholder="Enter email" autocomplete="email">
             </div>
 
             <div class="form-field">
               <label>Password</label>
               <div class="password-container">
-                <input type="password" id="password" class="password-input" required minlength="10" name="password" placeholder="Enter password">
+                <input type="password" id="password" class="password-input" required minlength="10" name="password"
+                  placeholder="Enter password" autocomplete="current-password">
                 <span id="toggle_password" class="toggle-password material-symbols-outlined">visibility_off</span>
               </div>
             </div>

--- a/mapp_v4/login/login_pl.html
+++ b/mapp_v4/login/login_pl.html
@@ -51,12 +51,13 @@
 
                         <div class="form-field">
                             <label>Adres e-maill</label>
-                            <input name="email" type="email" required maxlength="50">
+                            <input name="email" type="email" required maxlength="50" autocomplete="email">
                         </div>
 
                         <div class="form-field">
                             <label>Adres e-mail</label>
-                            <input name="password" type="password" required minlength="10">
+                            <input name="password" type="password" required minlength="10"
+                                autocomplete="current-password">
                         </div>
 
                         <button type="submit" class="button">Login</button>

--- a/mapp_v4/register.html
+++ b/mapp_v4/register.html
@@ -43,14 +43,15 @@
 
             <div class="form-field">
               <label>Email address</label>
-              <input name="email" type="email" autocomplete="off" required maxlength="50" value="" placeholder="Enter email">
+              <input name="email" type="email" autocomplete="off" required maxlength="50" value=""
+                placeholder="Enter email">
             </div>
 
             <div class="form-field">
               <label>Password</label>
               <div class="password-container">
-                <input type="password" id="password" class="password-input" required minlength="10" name="password" placeholder="Enter password"
-                  oninput="checkPassword()">
+                <input type="password" id="password" class="password-input" required minlength="10" name="password"
+                  placeholder="Enter password" oninput="checkPassword()" autocomplete="current-password">
                 <span id="toggle_password" class="toggle-password material-symbols-outlined">visibility_off</span>
               </div>
             </div>
@@ -58,8 +59,9 @@
             <div class="form-field">
               <label>Confirm Password</label>
               <div class="password-container">
-                <input type="password" id="confirm_password" class="password-input" required minlength="10" name="confirm_password" placeholder="Enter password"
-                  oninput="checkPassword()">
+                <input type="password" id="confirm_password" class="password-input" required minlength="10"
+                  name="confirm_password" placeholder="Enter password" oninput="checkPassword()"
+                  autocomplete="new-password">
                 <span id="toggle_confirm_password"
                   class="toggle-password material-symbols-outlined">visibility_off</span>
               </div>

--- a/mapp_v4/reset.html
+++ b/mapp_v4/reset.html
@@ -42,13 +42,13 @@
 
             <div class="form-field">
               <label>Email address</label>
-              <input name="email" type="email" autocomplete="off" required maxlength="50" value="" placeholder="Enter email">
+              <input name="email" type="email" autocomplete="email" required maxlength="50" value="" placeholder="Enter email">
 
               <div class="form-field">
                 <label>Password</label>
                 <div class="password-container">
                   <input type="password" id="password" class="password-input" placeholder="Enter password" required minlength="10" name="password"
-                    oninput="checkPassword()">
+                    oninput="checkPassword()" autocomplete="current-password">
                   <span id="toggle_password" class="toggle-password material-symbols-outlined">visibility_off</span>
                 </div>
               </div>
@@ -57,7 +57,7 @@
                 <label>Confirm Password</label>
                 <div class="password-container">
                   <input type="password" id="confirm_password" class="password-input" placeholder="Enter password" required minlength="10" name="confirm_password"
-                    oninput="checkPassword()">
+                    oninput="checkPassword()" autocomplete="new-password">
                   <span id="toggle_confirm_password"
                     class="toggle-password material-symbols-outlined">visibility_off</span>
                 </div>


### PR DESCRIPTION
Added the `autocomplete` attribute to the relevant password and email inputs to remove the Google Chrome about this. 

![image](https://github.com/GEOLYTIX/public/assets/56163132/eb89ef93-e39b-4158-a58c-a0a3ada17b2b)

Specification as linked in the Google Chrome warning here https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls%3A-the-autocomplete-attribute